### PR TITLE
fix note header style

### DIFF
--- a/packages/frontend/src/components/MkNoteHeader.vue
+++ b/packages/frontend/src/components/MkNoteHeader.vue
@@ -43,21 +43,13 @@ const headerWrapStyles = {
 	flexWrap: "wrap"
 };
 
-const headerOneLineStyles = {
-	display: "flex",
-};
-
-const headerRoleViewStyles = {
-	overflowX: "auto"
-};
-
 const headerContentStyles = {
 	flexShrink: "4",
 	textOverflow: "clip"
 };
 
 const roleScrollStyles = {
-	overflowX: "scroll"
+	overflowX: "auto"
 };
 
 const roleDisableStyles = {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ノートのヘッダーのロールバッチの下の方に必ずスクロールバーが表示されていたものの修正

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
`overflow-x` の値が `scroll` となっていたため、ロールバッチの長さに関係なくスクロールバーが出ていた

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
